### PR TITLE
WIP: circle.yml: Use Go 1.7

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+machine:
+  environment:
+    GOROOT: ~/go-1.7.4
+
+dependencies:
+  cache_directories:
+    - ~/go-1.7.4
+  pre:
+    - echo $PATH
+    - GOROOT= go version
+    - echo '47fda42e46b4c3ec93fa5d4d4cc6a748aa3f9411a2a2b7e08e3a6d80d753ec8b go1.7.4.linux-amd64.tar.gz' >go1.7.4.linux-amd64.tar.gz.hash
+    - test ! -d ~/go-1.7.4 && rm -rf ~/go-* && mkdir ~/go-1.7.4 && wget https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz && sha256sum -c go1.7.4.linux-amd64.tar.gz.hash && tar -C ~/go-1.7.4 -xzf go1.7.4.linux-amd64.tar.gz --strip-components 1
+    - go version


### PR DESCRIPTION
Avoid [our current failures][1]:

    go test -v -race ./...

    # github.com/docker/go-digest
    ./algorithm_test.go:43: t.Run undefined (type *testing.T has no field or method Run)
    ./verifiers_test.go:54: t.Run undefined (type *testing.T has no field or method Run)
    FAIL										github.com/docker/go-digest [build failed]

    go test -v -race ./... returned exit code 2

because `*T.Run` is [new in Go 1.7][2] and Circle is [currently using either Go 1.5.3 or 1.6.2][3].  More details in the commit message for the very curious ;).

[1]: https://circleci.com/gh/docker/go-digest/13#tests/containers/0
[2]: https://golang.org/doc/go1.7#testing
[3]: https://circleci.com/docs/language-go/#version