### PR TITLE
MAINTAINERS: add new maintainers to go-digest

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,7 @@
+Aaron Lehmann <aaron.lehmann@docker.com> (@aaronlehmann)
 Brandon Philips <brandon.philips@coreos.com> (@philips)
 Brendan Burns <bburns@microsoft.com> (@brendandburns)
+Derek McGowan <derek@mcgstyle.net> (@dmcgowan)
 Jason Bouzane <jbouzane@google.com> (@jbouzane)
 John Starks <jostarks@microsoft.com> (@jstarks)
 Jonathan Boulle <jon.boulle@coreos.com> (@jonboulle)


### PR DESCRIPTION
Aaron and Derek have long been instrumental in the maintenance and
integration of the original `digest` package. Since this package
provides such critical functionality, having their experience on board
will ensure that additions to this package can be made with confidence.

Signed-off-by: Stephen J Day <stephen.day@docker.com>