### PR TITLE
Revert "MAINTAINERS: add new maintainers to go-digest"

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,7 +1,5 @@
-Aaron Lehmann <aaron.lehmann@docker.com> (@aaronlehmann)
 Brandon Philips <brandon.philips@coreos.com> (@philips)
 Brendan Burns <bburns@microsoft.com> (@brendandburns)
-Derek McGowan <derek@mcgstyle.net> (@dmcgowan)
 Jason Bouzane <jbouzane@google.com> (@jbouzane)
 John Starks <jostarks@microsoft.com> (@jstarks)
 Jonathan Boulle <jon.boulle@coreos.com> (@jonboulle)


### PR DESCRIPTION
Reverts opencontainers/go-digest#25

per https://github.com/opencontainers/go-digest/pull/25#issuecomment-271591573 apparently I jumped the gun, apologies.