### PR TITLE
digest: update NewDigestFromHex signature to use Algorithm

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -49,7 +49,7 @@ func NewDigestFromBytes(alg Algorithm, p []byte) Digest {
 }
 
 // NewDigestFromHex returns a Digest from alg and a the hex encoded digest.
-func NewDigestFromHex(alg, hex string) Digest {
+func NewDigestFromHex(alg Algorithm, hex string) Digest {
 	return Digest(fmt.Sprintf("%s:%s", alg, hex))
 }
 

--- a/digest_test.go
+++ b/digest_test.go
@@ -98,7 +98,7 @@ func TestParseDigest(t *testing.T) {
 			t.Fatalf("expected equal: %q != %q", newParsed, digest)
 		}
 
-		newFromHex := NewDigestFromHex(newParsed.Algorithm().String(), newParsed.Hex())
+		newFromHex := NewDigestFromHex(newParsed.Algorithm(), newParsed.Hex())
 		if newFromHex != digest {
 			t.Fatalf("%v != %v", newFromHex, digest)
 		}


### PR DESCRIPTION
For consistency reasons, make NewDigestFromHex also take an Algorithm as
the alg argument.

Signed-off-by: Aleksa Sarai <asarai@suse.de>