### PR TITLE
*: clarify we only deal with hex-encoded digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please see the [godoc](https://godoc.org/github.com/opencontainers/go-digest) fo
 
 # What is a digest?
 
-A digest is just a hash.
+A digest is just a [hash](https://en.wikipedia.org/wiki/Hash_function).
 
 The most common use case for a digest is to create a content
 identifier for use in [Content Addressable Storage](https://en.wikipedia.org/wiki/Content-addressable_storage)
@@ -60,17 +60,20 @@ out when using this package.
     ```go
     import (
         _ "crypto/sha256"
-   	    _ "crypto/sha512"
+        _ "crypto/sha512"
     )
     ```
     This may seem inconvenient but it allows you replace the hash 
     implementations with others, such as https://github.com/stevvooe/resumable.
  
-2. Even though `digest.Digest` may be assemable as a string, _always_ 
+2. Even though `digest.Digest` may be assemblable as a string, _always_ 
     verify your input with `digest.Parse` or use `Digest.Validate`
     when accepting untrusted input. While there are measures to 
     avoid common problems, this will ensure you have valid digests
     in the rest of your application.
+
+3. While alternative encodings of hash values (digests) are possible (for
+    example, base64), this package deals exclusively with hex-encoded digests.
 
 # Stability
 

--- a/doc.go
+++ b/doc.go
@@ -32,6 +32,8 @@
 // In this case, the string "sha256" is the algorithm and the hex bytes are
 // the "digest".
 //
+// This package exclusively uses hex encoding for all digests.
+//
 // Because the Digest type is simply a string, once a valid Digest is
 // obtained, comparisons are cheap, quick and simple to express with the
 // standard equality operator.

--- a/doc.go
+++ b/doc.go
@@ -29,10 +29,13 @@
 //
 // 	sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
 //
-// In this case, the string "sha256" is the algorithm and the hex bytes are
-// the "digest".
+// The "algorithm" portion defines both the hashing algorithm used to calculate
+// the digest and the encoding of the resulting digest, which defaults to "hex"
+// if not otherwise specified. Currently, all supported algorithms have their
+// digests encoded in hex strings.
 //
-// This package exclusively uses hex encoding for all digests.
+// In the example above, the string "sha256" is the algorithm and the hex bytes
+// are the "digest".
 //
 // Because the Digest type is simply a string, once a valid Digest is
 // obtained, comparisons are cheap, quick and simple to express with the


### PR DESCRIPTION
Also fixes a typo and adds one clarifying link in the README.

Fixes #31