### PR TITLE
algorithm: Deprecate ErrDigestInvalidLength

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -180,11 +180,6 @@ func (a Algorithm) Validate(encoded string) error {
 	if !ok {
 		return ErrDigestUnsupported
 	}
-	// Digests much always be hex-encoded, ensuring that their hex portion will
-	// always be size*2
-	if a.Size()*2 != len(encoded) {
-		return ErrDigestInvalidLength
-	}
 	if r.MatchString(encoded) {
 		return nil
 	}

--- a/digest.go
+++ b/digest.go
@@ -68,8 +68,8 @@ var (
 	// ErrDigestInvalidFormat returned when digest format invalid.
 	ErrDigestInvalidFormat = fmt.Errorf("invalid checksum digest format")
 
-	// ErrDigestInvalidLength returned when digest has invalid length.
-	ErrDigestInvalidLength = fmt.Errorf("invalid checksum digest length")
+	// ErrDigestInvalidLength is deprecated.  Please use ErrDigestInvalidFormat.
+	ErrDigestInvalidLength = ErrDigestInvalidFormat
 
 	// ErrDigestUnsupported returned when the digest algorithm is unsupported.
 	ErrDigestUnsupported = fmt.Errorf("unsupported digest algorithm")

--- a/digest_test.go
+++ b/digest_test.go
@@ -36,6 +36,10 @@ func TestParseDigest(t *testing.T) {
 			encoded:   "d3fc7881460b7e22e3d172954463dddd7866d17597e7248453c48b3e9d26d9596bf9c4a9cf8072c9d5bad76e19af801d",
 		},
 		{
+			input: "",
+			err:   ErrDigestInvalidFormat,
+		},
+		{
 			// empty hex
 			input: "sha256:",
 			err:   ErrDigestInvalidFormat,
@@ -53,17 +57,17 @@ func TestParseDigest(t *testing.T) {
 		{
 			// not hex
 			input: "sha256:d41d8cd98f00b204e9800m98ecf8427e",
-			err:   ErrDigestInvalidLength,
+			err:   ErrDigestInvalidFormat,
 		},
 		{
 			// too short
 			input: "sha256:abcdef0123456789",
-			err:   ErrDigestInvalidLength,
+			err:   ErrDigestInvalidFormat,
 		},
 		{
 			// too short (from different algorithm)
 			input: "sha512:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
-			err:   ErrDigestInvalidLength,
+			err:   ErrDigestInvalidFormat,
 		},
 		{
 			input: "foo:d41d8cd98f00b204e9800998ecf8427e",


### PR DESCRIPTION
This error was added in 97212540 (Validate digest length on parsing, 2015-12-02) and motivated [with][1]:

> The new error is mostly so that digest.Set doesn't need a special way to figure out if invalid digest had a algorithm prefix or not.

That doesn't make sense to me, because `Digest.Validate` returns `ErrDigestUnsupported` when there is no algorithm prefix (I've added a test to confirm this as well), and that seems orthogonal to encoding validation (which is the only place `ErrDigestInvalidLength` could matter).  From the other changes in docker/distribution#1231, I think the issue was just that invalid lengths weren't raising errors at all.

I see no reason to distinguish between invalid lengths, invalid characters, and other invalid-encoded-portion errors, so this commit collapses the error into `ErrDigestInvalidFormat`.

The code I'm removing assumed hex (with `.Size() * 2`), so this PR removes that assumption.  The `sha256` and other hex-based algorithms are still getting their lengths validated via `anchoredEncodedRegexps`.

This PR is based on [my earlier suggestion][2].  I think @AkihiroSuda kept the error because of @stevvooe's [comment][3]:

> This needs to remain. Are we no longer throwing this error?

but with this PR we will continue throwing *an* error in the invalid-length case and folks who are switching on `ErrDigestInvalidLength` can continue to do so.  It's just that they'll no longer be able to distinguish between `ErrDigestInvalidLength` and	`ErrDigestInvalidFormat`, and since I see no reason to do that, I don't see it as an important backwards-compat concern.  If someone *does* have a reason to make that distinction, pointing at that code would be a good reason to close this PR.

[1]: https://github.com/docker/distribution/pull/1231
[2]: https://github.com/opencontainers/go-digest/pull/34#discussion_r117521717
[3]: https://github.com/opencontainers/go-digest/pull/34#discussion_r118557230