### PR TITLE
algorithm: ErrDigestInvalidFormat on Validate() even for unknown algorithms

### DIFF
--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -160,7 +160,7 @@ func TestValidate(t *testing.T) {
 			// unsupported, but the encoded part cannot possibly be valid because it contains invalid characters
 			encoded:   "!",
 			algorithm: "foo",
-			err:       ErrDigestUnsupported,
+			err:       ErrDigestInvalidFormat,
 		},
 		{
 			// uppercase
@@ -172,6 +172,47 @@ func TestValidate(t *testing.T) {
 		err := testcase.algorithm.Validate(testcase.encoded)
 		if err != testcase.err {
 			t.Fatalf("error differed from expected while validating %q: %v != %v", testcase.encoded, err, testcase.err)
+		}
+	}
+}
+
+func TestValidateIdentifier(t *testing.T) {
+	for _, testcase := range []struct {
+		algorithm Algorithm
+		err       error
+	}{
+		{
+			algorithm: "sha256",
+		},
+		{
+			algorithm: "sha384",
+		},
+		{
+			// empty identifier
+			algorithm: "",
+			err:       ErrDigestInvalidFormat,
+		},
+		{
+			// repeated separators
+			algorithm: "sha384__foo+bar",
+			err:       ErrDigestInvalidFormat,
+		},
+		{
+			// ensure that we parse valid separators
+			algorithm: "sha384.foo+bar",
+		},
+		{
+			// ensure that we parse valid separators
+			algorithm: "sha384_foo+bar",
+		},
+		{
+			// ensure that we parse valid separators
+			algorithm: "sha256+b64",
+		},
+	} {
+		err := testcase.algorithm.ValidateIdentifier()
+		if err != testcase.err {
+			t.Fatalf("error differed from expected while validating identifier %q: %v != %v", testcase.algorithm, err, testcase.err)
 		}
 	}
 }

--- a/digest_test.go
+++ b/digest_test.go
@@ -70,6 +70,11 @@ func TestParseDigest(t *testing.T) {
 			err:   ErrDigestUnsupported,
 		},
 		{
+			// unsupported, but the encoded part cannot possibly be valid because it contains invalid characters
+			input: "foo:!",
+			err:   ErrDigestInvalidFormat,
+		},
+		{
 			// repeated separators
 			input: "sha384__foo+bar:d3fc7881460b7e22e3d172954463dddd7866d17597e7248453c48b3e9d26d9596bf9c4a9cf8072c9d5bad76e19af801d",
 			err:   ErrDigestInvalidFormat,


### PR DESCRIPTION
In some cases (e.g. `Algorithm("foo").Validate("!")`) we know the encoded portion is invalid even if we do not have an entry for `foo` in `anchoredEncodedRegexps`.  Whatever algorithm-specific additional restrictions are applied via `anchoredEncodedRegexps`, the encoded portion must satisfy the generic encoded-portion restrictions from the `DigestRegexp`.  This commit adjusts the `Algorithm("foo").Validate("!")` result to match the current `Digest("foo:!").Validate()` result, and factors the encoded portion of `DigestRegexp` out into `encodedRegexp` and `encodedRegexpAnchored` as I'd [recommended here][1].

It also guards the `Size()`-based length check with `Available()`, because `Size()` returns zero for unavailable algorithms.  Now that we have a check for algorithms that aren't in `anchoredEncodedRegexps`, we can't rely on lookup-misses there to protect us from running the `Size()` check on unavailable algorithms.  And equating `anchoredEncodedRegexps` hits with `Available` was dicey anyway, since it depended on what packages get loaded, etc.  In #35 I'm dropping this `Size` check entirely, but I'm happy to rebase whichever PR lands second.

[1]: https://github.com/opencontainers/go-digest/pull/34#discussion_r116304776