### PR TITLE
add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/opencontainers/go-digest
+
+go 1.13


### PR DESCRIPTION
Although the package doesn't have any extra dependency, having `go.mod` would be
good to ensure that the package supports go mod.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>