### PR TITLE
Implement dynamic hash registration

### DIFF
--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -17,6 +17,7 @@ package digest
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/rand"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
@@ -112,4 +113,40 @@ func TestFroms(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestBadAlgorithmNameRegistration(t *testing.T) {
+	expectPanic := func(algorithm string) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("Expected panic and did not find one")
+			}
+			t.Logf("Captured panic: %v", r)
+		}()
+		// We just use SHA256 here as a test / stand-in
+		RegisterAlgorithm(Algorithm(algorithm), crypto.SHA256)
+	}
+
+	expectPanic("sha256-")
+	expectPanic("-")
+	expectPanic("SHA256")
+	expectPanic("sha25*")
+}
+
+func TestGoodAlgorithmNameRegistration(t *testing.T) {
+	expectNoPanic := func(algorithm string) {
+		defer func() {
+			r := recover()
+			if r != nil {
+				t.Fatalf("Expected panic and found one: %v", r)
+			}
+		}()
+
+		// We just use SHA256 here as a test / stand-in
+		RegisterAlgorithm(Algorithm(algorithm), crypto.SHA256)
+	}
+
+	expectNoPanic("sha256-test")
+	expectNoPanic("sha256_384")
 }

--- a/sha.go
+++ b/sha.go
@@ -1,0 +1,17 @@
+package digest
+
+import (
+	"crypto"
+)
+
+const (
+	SHA256 Algorithm = "sha256" // sha256 with hex encoding (lower case only)
+	SHA384 Algorithm = "sha384" // sha384 with hex encoding (lower case only)
+	SHA512 Algorithm = "sha512" // sha512 with hex encoding (lower case only)
+)
+
+func init() {
+	RegisterAlgorithm(SHA256, crypto.SHA256)
+	RegisterAlgorithm(SHA384, crypto.SHA384)
+	RegisterAlgorithm(SHA512, crypto.SHA512)
+}


### PR DESCRIPTION
This adds a new interface to go-digest allowing for it to act as a registry
for various hash implementations. It includes the new "CryptoHash" interface
which hashers must implement. By default the SHA variants that were
historically available are available.

The cryptoHash interface mimics crypto.Hash, but is a subset of the methods
that we require. crypto.Hash is a concrete type that makes it hard to bring
new hash function implementations in.

The primary impetus is to allow for out-of-tree hash implementations to be
added. For example, if someone wanted to add the out-of-tree BLAKE3 AVX
implementation, they could do that. Right now, if two versions of the same
implementation are added, the one that is added first will take precedence,
but in the future, we can add the ability to force registration.

Signed-off-by: Sargun Dhillon <sargun@sargun.me>