### PR TITLE
make sure the standard algorithms are registered

### DIFF
--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -19,8 +19,6 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/rand"
-	_ "crypto/sha256"
-	_ "crypto/sha512"
 	"flag"
 	"fmt"
 	"strings"

--- a/digestset/set_test.go
+++ b/digestset/set_test.go
@@ -17,7 +17,6 @@ package digestset
 
 import (
 	"crypto/sha256"
-	_ "crypto/sha512"
 	"encoding/binary"
 	"math/rand"
 	"testing"

--- a/sha.go
+++ b/sha.go
@@ -2,6 +2,12 @@ package digest
 
 import (
 	"crypto"
+
+	// make sure crypto.SHA256 is registered
+	_ "crypto/sha256"
+
+	// make sure crypto.sha512 and crypto.SHA384 are registered
+	_ "crypto/sha512"
 )
 
 const (


### PR DESCRIPTION
This makes sure that the expected algorithms are registered when using this package.

Currently, the consumer of the package must import these, otherwise it's not registered, resultig in "unsupported digest algorithm" errors.


relates to https://github.com/moby/moby/pull/42755#issuecomment-901083537