### PR TITLE
fix deprecation of NewDigestFromHex and Digest.Hex

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -39,9 +39,7 @@ const (
 	BLAKE3 Algorithm = "blake3"
 )
 
-var (
-	algorithmRegexp = regexp.MustCompile(`^[a-z0-9]+([+._-][a-z0-9]+)*$`)
-)
+var algorithmRegexp = regexp.MustCompile(`^[a-z0-9]+([+._-][a-z0-9]+)*$`)
 
 // CryptoHash is the interface that any hash algorithm must implement
 type CryptoHash interface {

--- a/blake3/blake3.go
+++ b/blake3/blake3.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//	https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/blake3/blake3_test.go
+++ b/blake3/blake3_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//	https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/digest.go
+++ b/digest.go
@@ -30,7 +30,7 @@ import (
 //
 // The following is an example of the contents of Digest types:
 //
-// 	sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
+//	sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
 //
 // This allows to abstract the digest behind this type and work only in those
 // terms.

--- a/digest.go
+++ b/digest.go
@@ -49,7 +49,9 @@ func NewDigestFromBytes(alg Algorithm, p []byte) Digest {
 	return NewDigestFromEncoded(alg, alg.Encode(p))
 }
 
-// NewDigestFromHex is deprecated. Please use NewDigestFromEncoded.
+// NewDigestFromHex returns a Digest from alg and the hex encoded digest.
+//
+// Deprecated: use [NewDigestFromEncoded] instead.
 func NewDigestFromHex(alg, hex string) Digest {
 	return NewDigestFromEncoded(Algorithm(alg), hex)
 }
@@ -137,7 +139,10 @@ func (d Digest) Encoded() string {
 	return string(d[d.sepIndex()+1:])
 }
 
-// Hex is deprecated. Please use Digest.Encoded.
+// Hex returns the encoded portion of the digest. This will panic if the
+// underlying digest is not in a valid format.
+//
+// Deprecated: [Digest.Encoded] instead.
 func (d Digest) Hex() string {
 	return d.Encoded()
 }

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -99,7 +99,7 @@ func (dst *Set) Lookup(d string) (digest.Digest, error) {
 			return dst.entries[i].val >= d
 		}
 	} else {
-		hex = dgst.Hex()
+		hex = dgst.Encoded()
 		alg = dgst.Algorithm()
 		searchFunc = func(i int) bool {
 			if dst.entries[i].val == hex {
@@ -131,7 +131,7 @@ func (dst *Set) Add(d digest.Digest) error {
 	}
 	dst.mutex.Lock()
 	defer dst.mutex.Unlock()
-	entry := &digestEntry{alg: d.Algorithm(), val: d.Hex(), digest: d}
+	entry := &digestEntry{alg: d.Algorithm(), val: d.Encoded(), digest: d}
 	searchFunc := func(i int) bool {
 		if dst.entries[i].val == entry.val {
 			return dst.entries[i].alg >= entry.alg
@@ -162,7 +162,7 @@ func (dst *Set) Remove(d digest.Digest) error {
 	}
 	dst.mutex.Lock()
 	defer dst.mutex.Unlock()
-	entry := &digestEntry{alg: d.Algorithm(), val: d.Hex(), digest: d}
+	entry := &digestEntry{alg: d.Algorithm(), val: d.Encoded(), digest: d}
 	searchFunc := func(i int) bool {
 		if dst.entries[i].val == entry.val {
 			return dst.entries[i].alg >= entry.alg

--- a/digestset/set_test.go
+++ b/digestset/set_test.go
@@ -201,7 +201,6 @@ func TestAll(t *testing.T) {
 			t.Fatalf("Missing element at position %d: %s", i, dgst)
 		}
 	}
-
 }
 
 func assertEqualShort(t *testing.T, actual, expected string) {
@@ -377,9 +376,11 @@ func BenchmarkLookup1000(b *testing.B) {
 func BenchmarkShortCode10(b *testing.B) {
 	benchShortCodeNTable(b, 10, 12)
 }
+
 func BenchmarkShortCode100(b *testing.B) {
 	benchShortCodeNTable(b, 100, 12)
 }
+
 func BenchmarkShortCode1000(b *testing.B) {
 	benchShortCodeNTable(b, 1000, 12)
 }

--- a/doc.go
+++ b/doc.go
@@ -19,16 +19,16 @@
 // More importantly, it provides tools and wrappers to work with
 // hash.Hash-based digests with little effort.
 //
-// Basics
+// # Basics
 //
 // The format of a digest is simply a string with two parts, dubbed the
 // "algorithm" and the "digest", separated by a colon:
 //
-// 	<algorithm>:<digest>
+//	<algorithm>:<digest>
 //
 // An example of a sha256 digest representation follows:
 //
-// 	sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
+//	sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
 //
 // The "algorithm" portion defines both the hashing algorithm used to calculate
 // the digest and the encoding of the resulting digest, which defaults to "hex"
@@ -42,7 +42,7 @@
 // obtained, comparisons are cheap, quick and simple to express with the
 // standard equality operator.
 //
-// Verification
+// # Verification
 //
 // The main benefit of using the Digest type is simple verification against a
 // given digest. The Verifier interface, modeled after the stdlib hash.Hash
@@ -50,7 +50,7 @@
 // writing is complete, calling the Verifier.Verified method will indicate
 // whether or not the stream of bytes matches the target digest.
 //
-// Missing Features
+// # Missing Features
 //
 // In addition to the above, we intend to add the following features to this
 // package:
@@ -58,5 +58,4 @@
 // 1. A Digester type that supports write sink digest calculation.
 //
 // 2. Suspend and resume of ongoing digest calculations to support efficient digest verification in the registry.
-//
 package digest

--- a/testdigest/testdigest.go
+++ b/testdigest/testdigest.go
@@ -27,48 +27,47 @@ import (
 
 type TestCase struct {
 	// Input the formal format of the hash, for example sha256:e58fcf7418d4390dec8e8fb69d88c06ec07039d651fedd3aa72af9972e7d046b
-	Input     string
+	Input string
 	// If err is non-nil, then the parsing of Input is expected to return this error
-	Err       error
+	Err error
 	// Algorithm should be an available or registered algorithm
 	Algorithm pkgdigest.Algorithm
 	// Encoded is the the encoded portion of the digest to expect, for example e58fcf7418d4390dec8e8fb69d88c06ec07039d651fedd3aa72af9972e7d046b
-	Encoded   string
+	Encoded string
 }
 
 func RunTestCase(t *testing.T, testcase TestCase) {
-		digest, err := pkgdigest.Parse(testcase.Input)
-		if err != testcase.Err {
-			t.Fatalf("error differed from expected while parsing %q: %v != %v", testcase.Input, err, testcase.Err)
-		}
+	digest, err := pkgdigest.Parse(testcase.Input)
+	if err != testcase.Err {
+		t.Fatalf("error differed from expected while parsing %q: %v != %v", testcase.Input, err, testcase.Err)
+	}
 
-		if testcase.Err != nil {
-			return
-		}
+	if testcase.Err != nil {
+		return
+	}
 
-		if digest.Algorithm() != testcase.Algorithm {
-			t.Fatalf("incorrect Algorithm for parsed digest: %q != %q", digest.Algorithm(), testcase.Algorithm)
-		}
+	if digest.Algorithm() != testcase.Algorithm {
+		t.Fatalf("incorrect Algorithm for parsed digest: %q != %q", digest.Algorithm(), testcase.Algorithm)
+	}
 
-		if digest.Encoded() != testcase.Encoded {
-			t.Fatalf("incorrect hex for parsed digest: %q != %q", digest.Encoded(), testcase.Encoded)
-		}
+	if digest.Encoded() != testcase.Encoded {
+		t.Fatalf("incorrect hex for parsed digest: %q != %q", digest.Encoded(), testcase.Encoded)
+	}
 
-		// Parse string return value and check equality
-		newParsed, err := pkgdigest.Parse(digest.String())
+	// Parse string return value and check equality
+	newParsed, err := pkgdigest.Parse(digest.String())
+	if err != nil {
+		t.Fatalf("unexpected error parsing Input %q: %v", testcase.Input, err)
+	}
 
-		if err != nil {
-			t.Fatalf("unexpected error parsing Input %q: %v", testcase.Input, err)
-		}
+	if newParsed != digest {
+		t.Fatalf("expected equal: %q != %q", newParsed, digest)
+	}
 
-		if newParsed != digest {
-			t.Fatalf("expected equal: %q != %q", newParsed, digest)
-		}
-
-		newFromHex := pkgdigest.NewDigestFromEncoded(newParsed.Algorithm(), newParsed.Encoded())
-		if newFromHex != digest {
-			t.Fatalf("%v != %v", newFromHex, digest)
-		}
+	newFromHex := pkgdigest.NewDigestFromEncoded(newParsed.Algorithm(), newParsed.Encoded())
+	if newFromHex != digest {
+		t.Fatalf("%v != %v", newFromHex, digest)
+	}
 }
 
 func RunTestCases(t *testing.T, testcases []TestCase) {

--- a/testdigest/testdigest_test.go
+++ b/testdigest/testdigest_test.go
@@ -15,10 +15,10 @@
 package testdigest
 
 import (
-	"testing"
-
 	_ "crypto/sha256"
 	_ "crypto/sha512"
+	"testing"
+
 	"github.com/opencontainers/go-digest"
 )
 
@@ -67,12 +67,12 @@ func TestParseDigest(t *testing.T) {
 		{
 			// not hex
 			Input: "sha256:d41d8cd98f00b204e9800m98ecf8427e",
-			Err:   digest. ErrDigestInvalidLength,
+			Err:   digest.ErrDigestInvalidLength,
 		},
 		{
 			// too short
 			Input: "sha256:abcdef0123456789",
-			Err:   digest. ErrDigestInvalidLength,
+			Err:   digest.ErrDigestInvalidLength,
 		},
 		{
 			// too short (from different Algorithm)
@@ -93,24 +93,23 @@ func TestParseDigest(t *testing.T) {
 			Input:     "sha384.foo+bar:d3fc7881460b7e22e3d172954463dddd7866d17597e7248453c48b3e9d26d9596bf9c4a9cf8072c9d5bad76e19af801d",
 			Algorithm: "sha384.foo+bar",
 			Encoded:   "d3fc7881460b7e22e3d172954463dddd7866d17597e7248453c48b3e9d26d9596bf9c4a9cf8072c9d5bad76e19af801d",
-			Err:       digest. ErrDigestUnsupported,
+			Err:       digest.ErrDigestUnsupported,
 		},
 		{
 			Input:     "sha384_foo+bar:d3fc7881460b7e22e3d172954463dddd7866d17597e7248453c48b3e9d26d9596bf9c4a9cf8072c9d5bad76e19af801d",
 			Algorithm: "sha384_foo+bar",
 			Encoded:   "d3fc7881460b7e22e3d172954463dddd7866d17597e7248453c48b3e9d26d9596bf9c4a9cf8072c9d5bad76e19af801d",
-			Err:       digest. ErrDigestUnsupported,
+			Err:       digest.ErrDigestUnsupported,
 		},
 		{
 			Input:     "sha256+b64:LCa0a2j_xo_5m0U8HTBBNBNCLXBkg7-g-YpeiGJm564",
 			Algorithm: "sha256+b64",
 			Encoded:   "LCa0a2j_xo_5m0U8HTBBNBNCLXBkg7-g-YpeiGJm564",
-			Err:       digest. ErrDigestUnsupported,
+			Err:       digest.ErrDigestUnsupported,
 		},
 		{
 			Input: "sha256:E58FCF7418D4390DEC8E8FB69D88C06EC07039D651FEDD3AA72AF9972E7D046B",
-			Err:   digest. ErrDigestInvalidFormat,
+			Err:   digest.ErrDigestInvalidFormat,
 		},
 	})
 }
-


### PR DESCRIPTION
Both of these were deprecated in 55f675811a1b915549933c64571fd86b2676ba76 (https://github.com/opencontainers/go-digest/pull/33), but the format of the GoDoc comments didn't follow the correct format, which causes them not being picked up by tools as "deprecated".

This patch:

- Fixes the comments to be in the right format.
- Updates uses in the codebase to use the alternatives.

Also gofmt'd the code (first commit)
