### PR TITLE
assorted (test) cleanups

### DIFF
--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -83,38 +83,40 @@ func TestFroms(t *testing.T) {
 	}
 
 	for alg := range algorithms {
-		h := alg.Hash()
-		h.Write(p)
-		expected := Digest(fmt.Sprintf("%s:%x", alg, h.Sum(nil)))
+		t.Run(string(alg), func(t *testing.T) {
+			h := alg.Hash()
+			h.Write(p)
+			expected := Digest(fmt.Sprintf("%s:%x", alg, h.Sum(nil)))
 
-		var readerDgst Digest
-		readerDgst, err = alg.FromReader(bytes.NewReader(p))
-		if err != nil {
-			t.Fatalf("error calculating hash from reader: %v", err)
-		}
-
-		dgsts := []Digest{
-			alg.FromBytes(p),
-			alg.FromString(string(p)),
-			readerDgst,
-		}
-
-		if alg == Canonical {
-			readerDgst, err = FromReader(bytes.NewReader(p))
+			var readerDgst Digest
+			readerDgst, err = alg.FromReader(bytes.NewReader(p))
 			if err != nil {
 				t.Fatalf("error calculating hash from reader: %v", err)
 			}
 
-			dgsts = append(dgsts,
-				FromBytes(p),
-				FromString(string(p)),
-				readerDgst)
-		}
-		for _, dgst := range dgsts {
-			if dgst != expected {
-				t.Fatalf("unexpected digest %v != %v", dgst, expected)
+			dgsts := []Digest{
+				alg.FromBytes(p),
+				alg.FromString(string(p)),
+				readerDgst,
 			}
-		}
+
+			if alg == Canonical {
+				readerDgst, err = FromReader(bytes.NewReader(p))
+				if err != nil {
+					t.Fatalf("error calculating hash from reader: %v", err)
+				}
+
+				dgsts = append(dgsts,
+					FromBytes(p),
+					FromString(string(p)),
+					readerDgst)
+			}
+			for _, dgst := range dgsts {
+				if dgst != expected {
+					t.Errorf("unexpected digest %v != %v", dgst, expected)
+				}
+			}
+		})
 	}
 }
 

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -77,13 +77,18 @@ func TestFlagInterface(t *testing.T) {
 
 func TestFroms(t *testing.T) {
 	p := make([]byte, 1<<20)
-	rand.Read(p)
+	_, err := rand.Read(p)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for alg := range algorithms {
 		h := alg.Hash()
 		h.Write(p)
 		expected := Digest(fmt.Sprintf("%s:%x", alg, h.Sum(nil)))
-		readerDgst, err := alg.FromReader(bytes.NewReader(p))
+
+		var readerDgst Digest
+		readerDgst, err = alg.FromReader(bytes.NewReader(p))
 		if err != nil {
 			t.Fatalf("error calculating hash from reader: %v", err)
 		}
@@ -95,7 +100,7 @@ func TestFroms(t *testing.T) {
 		}
 
 		if alg == Canonical {
-			readerDgst, err := FromReader(bytes.NewReader(p))
+			readerDgst, err = FromReader(bytes.NewReader(p))
 			if err != nil {
 				t.Fatalf("error calculating hash from reader: %v", err)
 			}

--- a/digest.go
+++ b/digest.go
@@ -118,7 +118,7 @@ func (d Digest) Validate() error {
 	return algorithm.Validate(encoded)
 }
 
-// Algorithm returns the algorithm portion of the digest. This will panic if
+// Algorithm returns the algorithm portion of the digest. It panics if
 // the underlying digest is not in a valid format.
 func (d Digest) Algorithm() Algorithm {
 	return Algorithm(d[:d.sepIndex()])
@@ -133,7 +133,7 @@ func (d Digest) Verifier() Verifier {
 	}
 }
 
-// Encoded returns the encoded portion of the digest. This will panic if the
+// Encoded returns the encoded portion of the digest. It panics if the
 // underlying digest is not in a valid format.
 func (d Digest) Encoded() string {
 	return string(d[d.sepIndex()+1:])

--- a/digest_test.go
+++ b/digest_test.go
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testdigest
+package digest_test
 
 import (
-	_ "crypto/sha256"
-	_ "crypto/sha512"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest/testdigest"
 )
 
 func TestParseDigest(t *testing.T) {
-	RunTestCases(t, []TestCase{
+	testdigest.RunTestCases(t, []testdigest.TestCase{
 		{
 			Input:     "sha256:e58fcf7418d4390dec8e8fb69d88c06ec07039d651fedd3aa72af9972e7d046b",
 			Algorithm: "sha256",


### PR DESCRIPTION
Some changes I had locally (got some more, but in a follow-up) :smile:


### move digest tests to root

These tests have to be in their own package to prevent a circular import
between testdigest and the main module, but Go allows for blackbox-testing
by using a "_test" package.

This patch:

- moves the test file to be next to the implementation.
- removes the redundant imports of "crypto/sha256" and "crypto/shasha512",
  as they are imported by default since 084376bb543d4ce80b030a77a6f51f3b3fd861dc

### TestFroms: fix some linting issues

Keep the linters happy:

- fix an unhandled error (but unlikely to happen)
- fix some variables being shadowed

### TestFroms: use sub-tests

Use sub-tests to not fail early if an algorithm fails.

With this change:

    === RUN   TestFroms
    === RUN   TestFroms/sha256
    === RUN   TestFroms/sha384
    === RUN   TestFroms/sha512
    --- PASS: TestFroms (0.02s)
        --- PASS: TestFroms/sha256 (0.01s)
        --- PASS: TestFroms/sha384 (0.00s)
        --- PASS: TestFroms/sha512 (0.00s)
    PASS

### gofmt, and touch-up some godoc

