### PR TITLE
drop obsolete Go versions, and add go1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/blake3/go.mod
+++ b/blake3/go.mod
@@ -1,12 +1,12 @@
 module github.com/opencontainers/go-digest/blake3
 
-go 1.15
+go 1.18
 
 require (
 	github.com/opencontainers/go-digest v0.0.0
 	github.com/zeebo/blake3 v0.1.1
 )
 
-replace (
- github.com/opencontainers/go-digest => ../
-)
+replace github.com/opencontainers/go-digest => ../
+
+require golang.org/x/sys v0.0.0-20201014080544-cc95f250f6bc // indirect

--- a/blake3/go.sum
+++ b/blake3/go.sum
@@ -1,6 +1,8 @@
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
 github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/blake3 v0.1.1 h1:Nbsts7DdKThRHHd+YNlqiGlRqGEF2bE2eXN+xQ1hsEs=
 github.com/zeebo/blake3 v0.1.1/go.mod h1:G9pM4qQwjRzF1/v7+vabMj/c5mWpGZ2Wzo3Eb4z0pb4=
+github.com/zeebo/pcg v1.0.0 h1:dt+dx+HvX8g7Un32rY9XWoYnd0NmKmrIzpHF7qiTDj0=
 github.com/zeebo/pcg v1.0.0/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 golang.org/x/sys v0.0.0-20201014080544-cc95f250f6bc h1:HVFDs9bKvTxP6bh1Rj9MCSo+UmafQtI8ZWDPVwVk9g4=
 golang.org/x/sys v0.0.0-20201014080544-cc95f250f6bc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/opencontainers/go-digest
 
-go 1.13
+go 1.18


### PR DESCRIPTION
- follow-up to https://github.com/opencontainers/go-digest/pull/85 (https://github.com/opencontainers/go-digest/pull/85#issuecomment-1414448308)

These versions were really old, and all reached EOL; let's update the minimum version for the next release, so that we can also start taking advantage of newer Go features.