### PR TITLE
Digest: use strings.Cut, and remove Digest.sepIndex()

### DIFF
--- a/digest_test.go
+++ b/digest_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestParseDigest(t *testing.T) {
-	testdigest.RunTestCases(t, []testdigest.TestCase{
+	tests := []testdigest.TestCase{
 		{
 			Input:     "sha256:e58fcf7418d4390dec8e8fb69d88c06ec07039d651fedd3aa72af9972e7d046b",
 			Algorithm: "sha256",
@@ -110,5 +110,11 @@ func TestParseDigest(t *testing.T) {
 			Input: "sha256:E58FCF7418D4390DEC8E8FB69D88C06EC07039D651FEDD3AA72AF9972E7D046B",
 			Err:   digest.ErrDigestInvalidFormat,
 		},
-	})
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Input, func(t *testing.T) {
+			testdigest.RunTestCase(t, tc)
+		})
+	}
 }

--- a/testdigest/testdigest.go
+++ b/testdigest/testdigest.go
@@ -69,11 +69,3 @@ func RunTestCase(t *testing.T, testcase TestCase) {
 		t.Fatalf("%v != %v", newFromHex, digest)
 	}
 }
-
-func RunTestCases(t *testing.T, testcases []TestCase) {
-	for _, testcase := range testcases {
-		t.Run(testcase.Input, func(t *testing.T) {
-			RunTestCase(t, testcase)
-		})
-	}
-}


### PR DESCRIPTION
- [x] depends on https://github.com/opencontainers/go-digest/pull/89

This requires go1.18 or up.
