### PR TITLE
blake3: fix copyright header being used as GoDoc

### DIFF
--- a/blake3/blake3.go
+++ b/blake3/blake3.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package blake3
 
 import (

--- a/blake3/blake3_test.go
+++ b/blake3/blake3_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package blake3
 
 import (


### PR DESCRIPTION
The copyright header did not have an empty line after, which resulted in it being considered an incorrectly formatted "Package" description; https://pkg.go.dev/github.com/opencontainers/go-digest/blake3

This patch adds an empty line to prevent that.