### PR TITLE
do not register sha384 by default

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -34,10 +34,6 @@ func init() {
 	// by implementations.
 	RegisterAlgorithm(SHA256, crypto.SHA256)
 	RegisterAlgorithm(SHA512, crypto.SHA512)
-	// SHA384 is registered by default but is not part of the OCI image
-	// specification, and its use should be discouraged for reasons other
-	// than backward-compatibility.
-	RegisterAlgorithm(SHA384, crypto.SHA384)
 }
 
 // Algorithm identifies and implementation of a digester by an identifier.
@@ -83,9 +79,16 @@ const (
 
 	// SHA384 is the SHA-384 ([RFC 6234]) digest algorithm  with hex encoding
 	// (lower case only). Use of the SHA384 digest algorithm is not recommended,
-	// and the [Canonical] algorithm is preferred.
+	// for reasons other than backward-compatibility, and the [Canonical]
+	// algorithm is preferred.
+	//
+	// SHA384 is not part of the [OCI image specification], and not registered
+	// by default. Implementers must register it if needed;
+	//
+	//	RegisterAlgorithm(SHA384, crypto.SHA384)
 	//
 	// [RFC 6234]: https://datatracker.ietf.org/doc/html/rfc6234
+	// [OCI image specification]: https://github.com/opencontainers/image-spec/blob/v1.0.2/descriptor.md#registered-algorithms
 	SHA384 Algorithm = "sha384" // sha384 with hex encoding (lower case only)
 
 	// BLAKE3 is the [BLAKE3 algorithm] with the default 256-bit output size.

--- a/digest_test.go
+++ b/digest_test.go
@@ -15,6 +15,7 @@
 package digest_test
 
 import (
+	"crypto"
 	"crypto/sha256"
 	"testing"
 
@@ -23,6 +24,9 @@ import (
 )
 
 func TestParseDigest(t *testing.T) {
+	// SHA-384 is not registered by default, but used in this test.
+	digest.RegisterAlgorithm(digest.SHA384, crypto.SHA384)
+
 	tests := []testdigest.TestCase{
 		{
 			Input:     "sha256:e58fcf7418d4390dec8e8fb69d88c06ec07039d651fedd3aa72af9972e7d046b",

--- a/digestset/set_test.go
+++ b/digestset/set_test.go
@@ -16,6 +16,7 @@
 package digestset
 
 import (
+	"crypto"
 	"crypto/sha256"
 	"encoding/binary"
 	"math/rand"
@@ -135,6 +136,8 @@ func TestAddDuplication(t *testing.T) {
 		t.Fatal("Duplicate digest insert should not increase entries size")
 	}
 
+	// SHA-384 is not registered by default, but used in this test.
+	digest.RegisterAlgorithm(digest.SHA384, crypto.SHA384)
 	if err := dset.Add(digest.Digest("sha384:123451111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111")); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
related:

- https://github.com/opencontainers/go-digest/pull/64
- https://github.com/opencontainers/go-digest/issues/91#issuecomment-1728133554
- https://github.com/opencontainers/distribution-spec/issues/494

The SHA-384 algorithm is not documented in the OCI image-spec ([1], [2]), and is not encouraged to be used. Commit 084376bb543d4ce80b030a77a6f51f3b3fd861dc registered all algorithms by default, but also included SHA-384.

This patch disables SHA-384 by default, to discourage its use.

[1]: https://github.com/opencontainers/image-spec/blob/v1.0.2/descriptor.md#digests
[2]: https://github.com/opencontainers/image-spec/blob/v1.0.2/descriptor.md#registered-algorithms