### PR TITLE
Implement `encoding.TextUnmarshaler` in `Digest`

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -157,3 +157,21 @@ func (d Digest) Hex() string {
 func (d Digest) String() string {
 	return string(d)
 }
+
+// UnmarshalText implements encoding.TextUnmarshaler (and affects encoding/json unmarshaling)
+//
+// This enforces that unmarshaled values are valid; otherwise Go would allow setting a Digest value to arbitrary strings,
+// causing a later panic or other misuse if users forget to call Validate().
+func (d *Digest) UnmarshalText(text []byte) error {
+	if len(text) == 0 { // This frequently happens in `json:",omitempty"` fields, and users are presumably ready to handle that.
+		*d = ""
+		return nil
+	}
+
+	value, err := Parse(string(text))
+	if err != nil {
+		return err
+	}
+	*d = value
+	return nil
+}


### PR DESCRIPTION
... to ensure invalid values are rejected.

Otherwise Go would allow setting a `Digest` value to arbitrary strings, causing a later panic or other misuse if users forget to call `Validate()`. (e.g. https://github.com/containers/image/pull/2403 ,  CVE-2024-3727 .)

I don’t think adding this validation should break correct programs, although it can’t quite be ruled out. I did observe this breaking unit tests which were using unrealistic invalid `Digest` values.