### PR TITLE
fix minor linting issues in tests

### DIFF
--- a/verifiers_test.go
+++ b/verifiers_test.go
@@ -25,12 +25,18 @@ import (
 
 func TestDigestVerifier(t *testing.T) {
 	p := make([]byte, 1<<20)
-	rand.Read(p)
+	_, err := rand.Read(p)
+	if err != nil {
+		t.Fatal(err)
+	}
 	digest := FromBytes(p)
 
 	verifier := digest.Verifier()
 
-	io.Copy(verifier, bytes.NewReader(p))
+	_, err = io.Copy(verifier, bytes.NewReader(p))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !verifier.Verified() {
 		t.Fatalf("bytes not verified")


### PR DESCRIPTION
Just to please the linters;

    verifiers_test.go:28:11: Error return value of `rand.Read` is not checked (errcheck)
        rand.Read(p)
                 ^
    verifiers_test.go:33:9: Error return value of `io.Copy` is not checked (errcheck)
        io.Copy(verifier, bytes.NewReader(p))
               ^
