### PR TITLE
Add NOTICE, and fix CC BY-SA 4.0 ambiguity

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        https://www.apache.org/licenses/
+                        http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -176,14 +176,24 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2019, 2020 OCI Contributors
-   Copyright 2016 Docker, Inc.
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       https://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+opencontainers/go-digest
+
+Copyright The OCI Contributors.
+Copyright 2016 Docker, Inc.
+
+Source code is licensed under the Apache License, Version 2.0.
+See LICENSE for details.
+
+Documentation files, including README.md and CONTRIBUTING.md,
+are licensed under the Creative Commons Attribution-ShareAlike
+4.0 International License (CC BY-SA 4.0). See LICENSE.docs
+for details.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Copyright © 2019, 2020 OCI Contributors
 Copyright © 2016 Docker, Inc.
 All rights reserved, except as follows.
 Code is released under the [Apache 2.0 license](LICENSE).
-This `README.md` file and the [`CONTRIBUTING.md`](CONTRIBUTING.md) file are licensed under the Creative Commons Attribution 4.0 International License under the terms and conditions set forth in the file [`LICENSE.docs`](LICENSE.docs).
+This `README.md` file and the [`CONTRIBUTING.md`](CONTRIBUTING.md) file are licensed under the Creative Commons Attribution-ShareAlike 4.0 International License under the terms and conditions set forth in the file [`LICENSE.docs`](LICENSE.docs).
 You may obtain a duplicate copy of the same license, titled CC BY-SA 4.0, at http://creativecommons.org/licenses/by-sa/4.0/.
 
 [security]: https://github.com/opencontainers/org/blob/master/security


### PR DESCRIPTION
- relates to https://github.com/opencontainers/go-digest/issues/68#issuecomment-4459358537

----

- Reset the Apache-2 License to be a pristine copy
- Add a NOTICE to mention copyright and licensing
- Update the README which referred to the docs license without "ShareAlike", but the license is CC BY-SA 4.0.
