### PR TITLE
digestset: detect ambiguous short codes across algorithms

### DIFF
--- a/digestset/set.go
+++ b/digestset/set.go
@@ -109,17 +109,30 @@ func (dst *Set) Lookup(d string) (digest.Digest, error) {
 		}
 	}
 	idx := sort.Search(len(dst.entries), searchFunc)
-	if idx == len(dst.entries) || !checkShortMatch(dst.entries[idx].alg, dst.entries[idx].val, string(alg), hex) {
+
+	// Entries whose value has hex as a prefix form a contiguous run starting
+	// at idx. Digests of a different algorithm may sort within that run, so a
+	// second matching entry is not necessarily adjacent to the first; scan the
+	// whole run instead of only inspecting idx and idx+1.
+	var match *digestEntry
+	for i := idx; i < len(dst.entries) && strings.HasPrefix(dst.entries[i].val, hex); i++ {
+		if !checkShortMatch(dst.entries[i].alg, dst.entries[i].val, string(alg), hex) {
+			continue
+		}
+		if dst.entries[i].alg == alg && dst.entries[i].val == hex {
+			// An exact whole-value match is unambiguous.
+			return dst.entries[i].digest, nil
+		}
+		if match != nil {
+			return "", ErrDigestAmbiguous
+		}
+		match = dst.entries[i]
+	}
+	if match == nil {
 		return "", ErrDigestNotFound
 	}
-	if dst.entries[idx].alg == alg && dst.entries[idx].val == hex {
-		return dst.entries[idx].digest, nil
-	}
-	if idx+1 < len(dst.entries) && checkShortMatch(dst.entries[idx+1].alg, dst.entries[idx+1].val, string(alg), hex) {
-		return "", ErrDigestAmbiguous
-	}
 
-	return dst.entries[idx].digest, nil
+	return match.digest, nil
 }
 
 // Add adds the given digest to the set. An error will be returned

--- a/digestset/set_test.go
+++ b/digestset/set_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"math/rand"
+	"strings"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
@@ -390,4 +391,32 @@ func BenchmarkShortCode100(b *testing.B) {
 
 func BenchmarkShortCode1000(b *testing.B) {
 	benchShortCodeNTable(b, 1000, 12)
+}
+
+// TestLookupAmbiguousAcrossAlgorithms verifies that an algorithm-scoped short
+// code is reported as ambiguous even when a digest of a different algorithm
+// sorts between the two matching entries. The two sha256 digests below share
+// the prefix "1234", so "sha256:1234" is ambiguous (see TestLookup). The sha512
+// digest's value also starts with "1234" and sorts lexically between them.
+func TestLookupAmbiguousAcrossAlgorithms(t *testing.T) {
+	sha256A := digest.Digest("sha256:1234" + strings.Repeat("0", 60))
+	sha256C := digest.Digest("sha256:1234" + strings.Repeat("1", 60))
+	sha512B := digest.Digest("sha512:12340" + strings.Repeat("5", 123))
+
+	dset := NewSet()
+	for _, d := range []digest.Digest{sha256A, sha512B, sha256C} {
+		if err := dset.Add(d); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := dset.Lookup("sha256:1234"); err != ErrDigestAmbiguous {
+		t.Fatalf("Lookup(%q) = %v; want ErrDigestAmbiguous", "sha256:1234", err)
+	}
+
+	// A different-algorithm entry that sorts first in the prefix run must not
+	// hide the matching entries either.
+	if _, err := dset.Lookup("sha512:12340"); err != nil {
+		t.Fatalf("Lookup(%q) = %v; want the sha512 digest", "sha512:12340", err)
+	}
 }


### PR DESCRIPTION
## What

`Set.Lookup` can return a single digest for a short code that actually matches more than one entry, instead of `ErrDigestAmbiguous`.

## Why

`Lookup` finds the first entry matching the query with a binary search, then decides ambiguity by checking only `entries[idx+1]`. `entries` is sorted by encoded value, so this relies on a second entry that shares the queried prefix being adjacent to the first.

That holds for a single-algorithm set, but not once the set mixes algorithms (e.g. sha256 and sha512). A digest of a different algorithm whose encoded value shares the same prefix can sort *between* two entries that match the algorithm-scoped query. The adjacent-only check then sees the non-matching neighbour, concludes the code is unambiguous, and returns one of the two matches. The same gap produces a false `ErrDigestNotFound` when the different-algorithm entry sorts first in the prefix run.

Example set:

```
sha256:1234<0…>    (64 hex)
sha512:12340<5…>   (128 hex — sorts between the two sha256 entries)
sha256:1234<1…>    (64 hex)
```

`Lookup("sha256:1234")` returns the first sha256 digest with a nil error, though both sha256 digests match; it should return `ErrDigestAmbiguous`.

## Fix

Scan the full contiguous run of entries whose value has the queried hex as a prefix, rather than only the adjacent entry. An exact whole-value match still short-circuits as unambiguous.

Added `TestLookupAmbiguousAcrossAlgorithms`, which fails before this change and passes after. The existing `TestLookup` and `go test ./...` stay green.
