### PR TITLE
digestset: cleanup/refactor, and touch-up GoDoc

### DIFF
--- a/digestset/set.go
+++ b/digestset/set.go
@@ -58,14 +58,6 @@ func NewSet() *Set {
 	return &Set{}
 }
 
-// checkShortMatch checks whether two digests match as either whole
-// values or short values. This function does not test equality,
-// rather whether the second value could match against the first
-// value.
-func checkShortMatch(alg digest.Algorithm, hex, shortAlg, shortHex string) bool {
-	return (shortAlg == "" || alg == digest.Algorithm(shortAlg)) && strings.HasPrefix(hex, shortHex)
-}
-
 // Lookup looks for a digest matching the given string representation.
 // If no digests could be found ErrDigestNotFound will be returned
 // with an empty digest value. If multiple matches are found
@@ -106,11 +98,12 @@ func (dst *Set) Lookup(d string) (digest.Digest, error) {
 		if !strings.HasPrefix(entry.val, hexPrefix) {
 			break
 		}
-		if !checkShortMatch(entry.alg, entry.val, string(alg), hexPrefix) {
+		if alg != "" && entry.alg != alg {
+			// Non-matching algorithm.
 			continue
 		}
-		if entry.alg == alg && entry.val == hexPrefix {
-			// An exact whole-value match is unambiguous.
+		if entry.val == hexPrefix {
+			// An exact encoded-value match is unambiguous.
 			return entry.digest, nil
 		}
 		if match != "" {

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -190,39 +190,38 @@ func (dst *Set) All() []digest.Digest {
 func ShortCodeTable(dst *Set, length int) map[digest.Digest]string {
 	dst.mutex.RLock()
 	defer dst.mutex.RUnlock()
-	m := make(map[digest.Digest]string, len(dst.entries))
-	l := length
+	shortCodes := make(map[digest.Digest]string, len(dst.entries))
+	codeLength := length
 	resetIdx := 0
-	for i := 0; i < len(dst.entries); i++ {
-		var short string
-		extended := true
-		for extended {
-			extended = false
-			if len(dst.entries[i].val) <= l {
-				short = dst.entries[i].digest.String()
-			} else {
-				short = dst.entries[i].val[:l]
-				for j := i + 1; j < len(dst.entries); j++ {
-					if strings.HasPrefix(dst.entries[j].val, short) {
-						if j > resetIdx {
-							resetIdx = j
-						}
-						extended = true
-					} else {
-						break
-					}
-				}
-				if extended {
-					l++
-				}
+	for i, entry := range dst.entries {
+		for {
+			if len(entry.val) <= codeLength {
+				shortCodes[entry.digest] = entry.digest.String()
+				break
 			}
+
+			short := entry.val[:codeLength]
+			extended := false
+			for j := i + 1; j < len(dst.entries); j++ {
+				if !strings.HasPrefix(dst.entries[j].val, short) {
+					break
+				}
+				if j > resetIdx {
+					resetIdx = j
+				}
+				extended = true
+			}
+			if !extended {
+				shortCodes[entry.digest] = short
+				break
+			}
+			codeLength++
 		}
-		m[dst.entries[i].digest] = short
 		if i >= resetIdx {
-			l = length
+			codeLength = length
 		}
 	}
-	return m
+	return shortCodes
 }
 
 type digestEntry struct {

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -150,12 +150,12 @@ func (dst *Set) Remove(d digest.Digest) error {
 	}
 	dst.mutex.Lock()
 	defer dst.mutex.Unlock()
-	entry := &digestEntry{alg: d.Algorithm(), val: d.Encoded(), digest: d}
+	alg, val := d.Algorithm(), d.Encoded()
 	idx := sort.Search(len(dst.entries), func(i int) bool {
-		if dst.entries[i].val == entry.val {
-			return dst.entries[i].alg >= entry.alg
+		if dst.entries[i].val == val {
+			return dst.entries[i].alg >= alg
 		}
-		return dst.entries[i].val >= entry.val
+		return dst.entries[i].val >= val
 	})
 	// Not found if idx is after or value at idx is not digest
 	if idx == len(dst.entries) || dst.entries[idx].digest != d {

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -58,10 +58,15 @@ func NewSet() *Set {
 	return &Set{}
 }
 
-// Lookup looks for a digest matching the given string representation.
-// If no digests could be found ErrDigestNotFound will be returned
-// with an empty digest value. If multiple matches are found
-// ErrDigestAmbiguous will be returned with an empty digest value.
+// Lookup looks for a digest matching d.
+//
+// d may be a full digest, such as "sha256:abcdef...", an encoded-value prefix,
+// such as "abcdef", or an algorithm-qualified encoded-value prefix, such as
+// "sha256:abcdef". An exact full-digest match takes precedence over other
+// prefix matches.
+//
+// If no digest matches, Lookup returns [ErrDigestNotFound]. If multiple prefix
+// matches are found, Lookup returns [ErrDigestAmbiguous].
 func (dst *Set) Lookup(d string) (digest.Digest, error) {
 	dst.mutex.RLock()
 	defer dst.mutex.RUnlock()
@@ -73,8 +78,12 @@ func (dst *Set) Lookup(d string) (digest.Digest, error) {
 		hexPrefix string
 	)
 	if dgst, err := digest.Parse(d); errors.Is(err, digest.ErrDigestInvalidFormat) {
+		// An input without a valid algorithm separator is treated as an
+		// unqualified encoded-value prefix.
 		hexPrefix = d
 	} else {
+		// digest.Parse still returns the parsed algorithm and encoded value for
+		// qualified short digests, together with digest.ErrDigestInvalidLength.
 		hexPrefix = dgst.Encoded()
 		alg = dgst.Algorithm()
 	}
@@ -82,10 +91,9 @@ func (dst *Set) Lookup(d string) (digest.Digest, error) {
 		return dst.entries[i].val >= hexPrefix
 	})
 
-	// Entries whose value have hexPrefix as a prefix form a contiguous run starting
-	// at idx. Digests of a different algorithm may sort within that run, so a
-	// second matching entry is not necessarily adjacent to the first; scan the
-	// whole run instead of only inspecting idx and idx+1.
+	// Entries whose values start with hexPrefix form a contiguous range beginning
+	// at idx. Entries for other algorithms may appear between matching entries,
+	// so scan the entire prefix range rather than only idx and idx+1.
 	var match digest.Digest
 	for _, entry := range dst.entries[idx:] {
 		if !strings.HasPrefix(entry.val, hexPrefix) {
@@ -170,7 +178,7 @@ func (dst *Set) Remove(d digest.Digest) error {
 	return nil
 }
 
-// All returns all the digests in the set
+// All returns a copy of all digests in the set.
 func (dst *Set) All() []digest.Digest {
 	dst.mutex.RLock()
 	defer dst.mutex.RUnlock()
@@ -182,11 +190,11 @@ func (dst *Set) All() []digest.Digest {
 	return retValues
 }
 
-// ShortCodeTable returns a map of Digest to unique short codes. The
-// length represents the minimum value, the maximum length may be the
-// entire value of digest if uniqueness cannot be achieved without the
-// full value. This function will attempt to make short codes as short
-// as possible to be unique.
+// ShortCodeTable returns the shortest unique code for each digest in dst.
+//
+// Codes are at least length characters long. A code may be extended up to the
+// digest's full string representation when its encoded value is not unique at
+// a shorter length.
 func ShortCodeTable(dst *Set, length int) map[digest.Digest]string {
 	dst.mutex.RLock()
 	defer dst.mutex.RUnlock()

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -101,25 +101,28 @@ func (dst *Set) Lookup(d string) (digest.Digest, error) {
 	// at idx. Digests of a different algorithm may sort within that run, so a
 	// second matching entry is not necessarily adjacent to the first; scan the
 	// whole run instead of only inspecting idx and idx+1.
-	var match *digestEntry
-	for i := idx; i < len(dst.entries) && strings.HasPrefix(dst.entries[i].val, hexPrefix); i++ {
-		if !checkShortMatch(dst.entries[i].alg, dst.entries[i].val, string(alg), hexPrefix) {
+	var match digest.Digest
+	for _, entry := range dst.entries[idx:] {
+		if !strings.HasPrefix(entry.val, hexPrefix) {
+			break
+		}
+		if !checkShortMatch(entry.alg, entry.val, string(alg), hexPrefix) {
 			continue
 		}
-		if dst.entries[i].alg == alg && dst.entries[i].val == hexPrefix {
+		if entry.alg == alg && entry.val == hexPrefix {
 			// An exact whole-value match is unambiguous.
-			return dst.entries[i].digest, nil
+			return entry.digest, nil
 		}
-		if match != nil {
+		if match != "" {
 			return "", ErrDigestAmbiguous
 		}
-		match = dst.entries[i]
+		match = entry.digest
 	}
-	if match == nil {
+	if match == "" {
 		return "", ErrDigestNotFound
 	}
 
-	return match.digest, nil
+	return match, nil
 }
 
 // Add adds the given digest to the set. An error will be returned

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -79,36 +79,36 @@ func (dst *Set) Lookup(d string) (digest.Digest, error) {
 	var (
 		searchFunc func(int) bool
 		alg        digest.Algorithm
-		hex        string
+		hexPrefix  string
 	)
 	dgst, err := digest.Parse(d)
 	if errors.Is(err, digest.ErrDigestInvalidFormat) {
-		hex = d
+		hexPrefix = d
 		searchFunc = func(i int) bool {
 			return dst.entries[i].val >= d
 		}
 	} else {
-		hex = dgst.Encoded()
+		hexPrefix = dgst.Encoded()
 		alg = dgst.Algorithm()
 		searchFunc = func(i int) bool {
-			if dst.entries[i].val == hex {
+			if dst.entries[i].val == hexPrefix {
 				return dst.entries[i].alg >= alg
 			}
-			return dst.entries[i].val >= hex
+			return dst.entries[i].val >= hexPrefix
 		}
 	}
 	idx := sort.Search(len(dst.entries), searchFunc)
 
-	// Entries whose value has hex as a prefix form a contiguous run starting
+	// Entries whose value have hexPrefix as a prefix form a contiguous run starting
 	// at idx. Digests of a different algorithm may sort within that run, so a
 	// second matching entry is not necessarily adjacent to the first; scan the
 	// whole run instead of only inspecting idx and idx+1.
 	var match *digestEntry
-	for i := idx; i < len(dst.entries) && strings.HasPrefix(dst.entries[i].val, hex); i++ {
-		if !checkShortMatch(dst.entries[i].alg, dst.entries[i].val, string(alg), hex) {
+	for i := idx; i < len(dst.entries) && strings.HasPrefix(dst.entries[i].val, hexPrefix); i++ {
+		if !checkShortMatch(dst.entries[i].alg, dst.entries[i].val, string(alg), hexPrefix) {
 			continue
 		}
-		if dst.entries[i].alg == alg && dst.entries[i].val == hex {
+		if dst.entries[i].alg == alg && dst.entries[i].val == hexPrefix {
 			// An exact whole-value match is unambiguous.
 			return dst.entries[i].digest, nil
 		}

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -77,27 +77,25 @@ func (dst *Set) Lookup(d string) (digest.Digest, error) {
 		return "", ErrDigestNotFound
 	}
 	var (
-		searchFunc func(int) bool
-		alg        digest.Algorithm
-		hexPrefix  string
+		idx       int
+		alg       digest.Algorithm
+		hexPrefix string
 	)
-	dgst, err := digest.Parse(d)
-	if errors.Is(err, digest.ErrDigestInvalidFormat) {
+	if dgst, err := digest.Parse(d); errors.Is(err, digest.ErrDigestInvalidFormat) {
 		hexPrefix = d
-		searchFunc = func(i int) bool {
+		idx = sort.Search(len(dst.entries), func(i int) bool {
 			return dst.entries[i].val >= d
-		}
+		})
 	} else {
 		hexPrefix = dgst.Encoded()
 		alg = dgst.Algorithm()
-		searchFunc = func(i int) bool {
+		idx = sort.Search(len(dst.entries), func(i int) bool {
 			if dst.entries[i].val == hexPrefix {
 				return dst.entries[i].alg >= alg
 			}
 			return dst.entries[i].val >= hexPrefix
-		}
+		})
 	}
-	idx := sort.Search(len(dst.entries), searchFunc)
 
 	// Entries whose value have hexPrefix as a prefix form a contiguous run starting
 	// at idx. Digests of a different algorithm may sort within that run, so a
@@ -134,13 +132,12 @@ func (dst *Set) Add(d digest.Digest) error {
 	dst.mutex.Lock()
 	defer dst.mutex.Unlock()
 	entry := &digestEntry{alg: d.Algorithm(), val: d.Encoded(), digest: d}
-	searchFunc := func(i int) bool {
+	idx := sort.Search(len(dst.entries), func(i int) bool {
 		if dst.entries[i].val == entry.val {
 			return dst.entries[i].alg >= entry.alg
 		}
 		return dst.entries[i].val >= entry.val
-	}
-	idx := sort.Search(len(dst.entries), searchFunc)
+	})
 	if idx == len(dst.entries) {
 		dst.entries = append(dst.entries, entry)
 		return nil
@@ -165,13 +162,12 @@ func (dst *Set) Remove(d digest.Digest) error {
 	dst.mutex.Lock()
 	defer dst.mutex.Unlock()
 	entry := &digestEntry{alg: d.Algorithm(), val: d.Encoded(), digest: d}
-	searchFunc := func(i int) bool {
+	idx := sort.Search(len(dst.entries), func(i int) bool {
 		if dst.entries[i].val == entry.val {
 			return dst.entries[i].alg >= entry.alg
 		}
 		return dst.entries[i].val >= entry.val
-	}
-	idx := sort.Search(len(dst.entries), searchFunc)
+	})
 	// Not found if idx is after or value at idx is not digest
 	if idx == len(dst.entries) || dst.entries[idx].digest != d {
 		return nil

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -62,19 +62,7 @@ func NewSet() *Set {
 // rather whether the second value could match against the first
 // value.
 func checkShortMatch(alg digest.Algorithm, hex, shortAlg, shortHex string) bool {
-	if len(hex) == len(shortHex) {
-		if hex != shortHex {
-			return false
-		}
-		if len(shortAlg) > 0 && string(alg) != shortAlg {
-			return false
-		}
-	} else if !strings.HasPrefix(hex, shortHex) {
-		return false
-	} else if len(shortAlg) > 0 && string(alg) != shortAlg {
-		return false
-	}
-	return true
+	return (shortAlg == "" || alg == digest.Algorithm(shortAlg)) && strings.HasPrefix(hex, shortHex)
 }
 
 // Lookup looks for a digest matching the given string representation.
@@ -229,7 +217,7 @@ func ShortCodeTable(dst *Set, length int) map[digest.Digest]string {
 			} else {
 				short = dst.entries[i].val[:l]
 				for j := i + 1; j < len(dst.entries); j++ {
-					if checkShortMatch(dst.entries[j].alg, dst.entries[j].val, "", short) {
+					if strings.HasPrefix(dst.entries[j].val, short) {
 						if j > resetIdx {
 							resetIdx = j
 						}

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -69,25 +69,18 @@ func (dst *Set) Lookup(d string) (digest.Digest, error) {
 		return "", ErrDigestNotFound
 	}
 	var (
-		idx       int
 		alg       digest.Algorithm
 		hexPrefix string
 	)
 	if dgst, err := digest.Parse(d); errors.Is(err, digest.ErrDigestInvalidFormat) {
 		hexPrefix = d
-		idx = sort.Search(len(dst.entries), func(i int) bool {
-			return dst.entries[i].val >= d
-		})
 	} else {
 		hexPrefix = dgst.Encoded()
 		alg = dgst.Algorithm()
-		idx = sort.Search(len(dst.entries), func(i int) bool {
-			if dst.entries[i].val == hexPrefix {
-				return dst.entries[i].alg >= alg
-			}
-			return dst.entries[i].val >= hexPrefix
-		})
 	}
+	idx := sort.Search(len(dst.entries), func(i int) bool {
+		return dst.entries[i].val >= hexPrefix
+	})
 
 	// Entries whose value have hexPrefix as a prefix form a contiguous run starting
 	// at idx. Digests of a different algorithm may sort within that run, so a

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -46,15 +46,13 @@ var (
 // appropriately long short code should be used.
 type Set struct {
 	mutex   sync.RWMutex
-	entries digestEntries
+	entries []*digestEntry
 }
 
 // NewSet creates an empty set of digests
 // which may have digests added.
 func NewSet() *Set {
-	return &Set{
-		entries: digestEntries{},
-	}
+	return &Set{}
 }
 
 // checkShortMatch checks whether two digests match as either whole
@@ -243,21 +241,4 @@ type digestEntry struct {
 	alg    digest.Algorithm
 	val    string
 	digest digest.Digest
-}
-
-type digestEntries []*digestEntry
-
-func (d digestEntries) Len() int {
-	return len(d)
-}
-
-func (d digestEntries) Less(i, j int) bool {
-	if d[i].val != d[j].val {
-		return d[i].val < d[j].val
-	}
-	return d[i].alg < d[j].alg
-}
-
-func (d digestEntries) Swap(i, j int) {
-	d[i], d[j] = d[j], d[i]
 }

--- a/digestset/set.go
+++ b/digestset/set.go
@@ -35,15 +35,15 @@ var (
 	ErrDigestAmbiguous = errors.New("ambiguous digest string")
 )
 
-// Set is used to hold a unique set of digests which
-// may be easily referenced by easily  referenced by a string
-// representation of the digest as well as short representation.
-// The uniqueness of the short representation is based on other
-// digests in the set. If digests are omitted from this set,
-// collisions in a larger set may not be detected, therefore it
-// is important to always do short representation lookups on
-// the complete set of digests. To mitigate collisions, an
-// appropriately long short code should be used.
+// Set holds a unique set of digests that may be referenced by their full or
+// shortened string representation.
+//
+// The uniqueness of a shortened representation depends on the other digests
+// in the set. If digests are omitted, collisions in a larger set may not be
+// detected. Short representation lookups should therefore always use the
+// complete set of digests and an appropriately long short code.
+//
+// The zero value of Set is ready for use.
 type Set struct {
 	mutex   sync.RWMutex
 	entries []*digestEntry
@@ -51,6 +51,9 @@ type Set struct {
 
 // NewSet creates an empty set of digests
 // which may have digests added.
+//
+// In most cases, new([Set]) (or just declaring a [Set] variable) is
+// sufficient to initialize a [Set].
 func NewSet() *Set {
 	return &Set{}
 }

--- a/digestset/set_test.go
+++ b/digestset/set_test.go
@@ -268,7 +268,7 @@ func benchAddNTable(b *testing.B, n int) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		dset := &Set{entries: digestEntries(make([]*digestEntry, 0, n))}
+		dset := &Set{entries: make([]*digestEntry, 0, n)}
 		for j := range digests {
 			if err = dset.Add(digests[j]); err != nil {
 				b.Fatal(err)
@@ -283,7 +283,7 @@ func benchLookupNTable(b *testing.B, n int, shortLen int) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	dset := &Set{entries: digestEntries(make([]*digestEntry, 0, n))}
+	dset := &Set{entries: make([]*digestEntry, 0, n)}
 	for i := range digests {
 		if err := dset.Add(digests[i]); err != nil {
 			b.Fatal(err)
@@ -310,7 +310,7 @@ func benchRemoveNTable(b *testing.B, n int) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		dset := &Set{entries: digestEntries(make([]*digestEntry, 0, n))}
+		dset := &Set{entries: make([]*digestEntry, 0, n)}
 		b.StopTimer()
 		for j := range digests {
 			if err = dset.Add(digests[j]); err != nil {
@@ -332,7 +332,7 @@ func benchShortCodeNTable(b *testing.B, n int, shortLen int) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	dset := &Set{entries: digestEntries(make([]*digestEntry, 0, n))}
+	dset := &Set{entries: make([]*digestEntry, 0, n)}
 	for i := range digests {
 		if err := dset.Add(digests[i]); err != nil {
 			b.Fatal(err)

--- a/digestset/set_test.go
+++ b/digestset/set_test.go
@@ -44,7 +44,7 @@ func TestLookup(t *testing.T) {
 		"sha256:6532111111111111111111111111111111111111111111111111111111111111",
 	}
 
-	dset := NewSet()
+	var dset Set
 	for i := range digests {
 		if err := dset.Add(digests[i]); err != nil {
 			t.Fatal(err)
@@ -118,7 +118,7 @@ func TestAddDuplication(t *testing.T) {
 		"sha512:65321111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
 	}
 
-	dset := NewSet()
+	var dset Set
 	for i := range digests {
 		if err := dset.Add(digests[i]); err != nil {
 			t.Fatal(err)
@@ -154,7 +154,7 @@ func TestRemove(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dset := NewSet()
+	var dset Set
 	for i := range digests {
 		if err := dset.Add(digests[i]); err != nil {
 			t.Fatal(err)
@@ -225,14 +225,14 @@ func TestShortCodeTable(t *testing.T) {
 		"sha256:6532111111111111111111111111111111111111111111111111111111111111",
 	}
 
-	dset := NewSet()
+	var dset Set
 	for i := range digests {
 		if err := dset.Add(digests[i]); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	dump := ShortCodeTable(dset, 2)
+	dump := ShortCodeTable(&dset, 2)
 
 	if len(dump) < len(digests) {
 		t.Fatalf("Error unexpected size: %d, expecting %d", len(dump), len(digests))


### PR DESCRIPTION
- follow-up to https://github.com/opencontainers/go-digest/pull/119#pullrequestreview-4869215744

Refactor / cleanup the code; slight improvements in Benchmarks, and very minor regression in some, but probably mostly noise;

```console
pkg: github.com/opencontainers/go-digest/digestset
cpu: Apple M3 Pro
                │  before.txt  │             after2.txt              │
                │    sec/op    │   sec/op     vs base                │
Add10-2           4.806µ ±  1%   4.858µ ± 1%   +1.07% (p=0.000 n=10)
Add100-2          59.79µ ±  1%   60.36µ ± 1%   +0.95% (p=0.005 n=10)
Add1000-2         680.6µ ±  1%   683.0µ ± 1%        ~ (p=0.089 n=10)
Remove10-2        6.123µ ±  1%   6.162µ ± 0%   +0.65% (p=0.000 n=10)
Remove100-2       63.32µ ±  0%   63.84µ ± 0%   +0.81% (p=0.001 n=10)
Remove1000-2      670.3µ ± 21%   672.4µ ± 1%        ~ (p=0.218 n=10)
Lookup10-2        29.88n ±  0%   27.66n ± 0%   -7.40% (p=0.000 n=10)
Lookup100-2       41.53n ±  1%   36.71n ± 0%  -11.60% (p=0.000 n=10)
Lookup1000-2      75.70n ±  1%   62.02n ± 3%  -18.08% (p=0.000 n=10)
ShortCode10-2     220.7n ±  1%   215.4n ± 1%   -2.36% (p=0.000 n=10)
ShortCode100-2    1.657µ ±  1%   1.595µ ± 1%   -3.77% (p=0.000 n=10)
ShortCode1000-2   19.44µ ±  1%   18.81µ ± 1%   -3.22% (p=0.000 n=10)
geomean           4.242µ         4.084µ        -3.71%

                │   before.txt   │              after2.txt               │
                │      B/op      │     B/op      vs base                 │
Add10-2             608.0 ± 0%       608.0 ± 0%       ~ (p=1.000 n=10) ¹
Add100-2          5.609Ki ± 0%     5.609Ki ± 0%       ~ (p=1.000 n=10) ¹
Add1000-2         54.93Ki ± 0%     54.93Ki ± 0%       ~ (p=1.000 n=10) ¹
Remove10-2          128.0 ± 0%       128.0 ± 0%       ~ (p=1.000 n=10) ¹
Remove100-2         944.0 ± 0%       944.0 ± 0%       ~ (p=1.000 n=10) ¹
Remove1000-2      8.047Ki ± 0%     8.047Ki ± 0%       ~ (p=1.000 n=10) ¹
Lookup10-2          0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Lookup100-2         0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Lookup1000-2        0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
ShortCode10-2       664.0 ± 0%       664.0 ± 0%       ~ (p=1.000 n=10) ¹
ShortCode100-2    4.836Ki ± 0%     4.836Ki ± 0%       ~ (p=1.000 n=10) ¹
ShortCode1000-2   80.12Ki ± 0%     80.12Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                        ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                │  before.txt   │              after2.txt              │
                │   allocs/op   │  allocs/op   vs base                 │
Add10-2            12.00 ± 0%      12.00 ± 0%       ~ (p=1.000 n=10) ¹
Add100-2           102.0 ± 0%      102.0 ± 0%       ~ (p=1.000 n=10) ¹
Add1000-2         1.002k ± 0%     1.002k ± 0%       ~ (p=1.000 n=10) ¹
Remove10-2         2.000 ± 0%      2.000 ± 0%       ~ (p=1.000 n=10) ¹
Remove100-2        2.000 ± 0%      2.000 ± 0%       ~ (p=1.000 n=10) ¹
Remove1000-2       2.000 ± 0%      2.000 ± 0%       ~ (p=1.000 n=10) ¹
Lookup10-2         0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
Lookup100-2        0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
Lookup1000-2       0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
ShortCode10-2      4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=10) ¹
ShortCode100-2     4.000 ± 0%      4.000 ± 0%       ~ (p=1.000 n=10) ¹
ShortCode1000-2    6.000 ± 0%      6.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                       ²                +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```


### digestset: simplify short digest matching

Use strings.HasPrefix for full-length and shortened values, consolidate the
optional algorithm check, and use strings.HasPrefix directly where no
algorithm is specified.

This preserves the existing behavior while making the matching logic easier
to follow.

### digestset: remove redundant digestEntries type

The digestEntries type was added as part of the original implementation in
[distribution@8aacddd]; it implements `sort.Interface`, but this was never
used (there's no `sort.Sort` on the slice, and `sort.Search` does not use
it).

Replace it with a plain slice, and remove initialization from `NewSet`,
because the zero-value is usable for this package.

[distribution@8aacddd]: https://github.com/distribution/distribution/commit/7258fda98a033732325d2ef71c856a755197f46a


### digestset: document, and use zero values for Set

Document that the zero-value of Set is usable, borrowing some wording
from stdlib's bytes.NewBuffer (which is similar), and replace uses of
NewSet in our tests.


### digestset: rename hex var for clarity

The hex value is either a full hex (encoded) value, or a prefix;
rename the var to more clearly indicate it may be partial.


### digestset: inline searchFuncs

This avoids a function-scoped variable for the searchFunc, whereas
we're only interested in the result (idx).


### digestset: simplify entries loop

Use a basic range loop, starting at the idx from the binary-search,
and store the digest itself as match, instead of using digestEntry
as intermediate.


### digestset: inline checkShortMatch

Now that it's only used in a single place, we can open-code it to
make it more transparent what logic is used.


### digestset: remove redundant lookup search

Use a single binary search to find the start of the matching encoded-value
prefix range. The subsequent scan must already inspect the complete range to
detect ambiguity and already filters by algorithm, making the second
algorithm-aware search redundant.

### digestset: Remove: remove intermediate digestEntry struct

### digestset: simplify short-code generation

Range over entries directly and refactor the loop to make the
prefix extension and completion logic easier to follow.


### digestset: touch-up some GoDoc
